### PR TITLE
simplify truffle-config, remove imports and reduce gas settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "standard": "^12.0.1",
     "truffle": "^5.0.15",
     "truffle-assertions": "^0.8.0",
-    "truffle-privatekey-provider": "^0.1.0",
     "truffle-typings": "^1.0.6",
     "web3": "^1.0.0-beta.37"
   },

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -6,14 +6,14 @@ module.exports = {
       port: 8545,
       network_id: '*', // Match any network id
       gasPrice: 10000000000,
-      gas: 4800000
+      gas: 6700000
     },
     ganache: {
       host: '127.0.0.1',
       port: 8545,
       network_id: '*', // eslint-disable-line camelcase
       gasPrice: 10000000000,
-      gas: 4800000
+      gas: 6700000
     },
     localUnlimited: {
       host: "localhost",

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,10 +1,3 @@
-const PrivateKeyProvider = require('truffle-privatekey-provider')
-const dotenv = require('dotenv')
-const path = require('path')
-
-dotenv.config({ path: path.resolve(__dirname, './.env.truffle') })
-const privateKey = process.env.PRIVATE_KEY
-const apiKey = process.env.INFURA_API_KEY
 
 module.exports = {
   networks: {
@@ -13,24 +6,15 @@ module.exports = {
       port: 8545,
       network_id: '*', // Match any network id
       gasPrice: 10000000000,
-      gas: 7000000
+      gas: 4800000
     },
     ganache: {
       host: '127.0.0.1',
       port: 8545,
       network_id: '*', // eslint-disable-line camelcase
       gasPrice: 10000000000,
-      gas: 7000000
-    },
-    rinkeby: privateKey ? ({
-      provider: new PrivateKeyProvider(
-        privateKey,
-        'https://rinkeby.infura.io/' + apiKey
-      ),
-      network_id: '4', // eslint-disable-line camelcase
-      gasPrice: 10000000000,
       gas: 4800000
-    }) : undefined,
+    },
     localUnlimited: {
       host: "localhost",
       network_id: "*",


### PR DESCRIPTION
Changes:

Removed rinkeby deploy from truffle-config.js
Removed any external imports in truffle-config.js to remove use of PrivateKeyProvider
Reduced gas settings for development and ganache to be within max gasLimit of default ganache-cli start